### PR TITLE
Version 1.0.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aws-data-mesh-utils
-version = 1.0.6
+version = 1.0.7
 author = Ian Meyers
 author_email = meyersi@amazon.co.uk
 license = Apache 2.0

--- a/src/data_mesh_util/lib/constants.py
+++ b/src/data_mesh_util/lib/constants.py
@@ -1,7 +1,7 @@
 DEFAULT_TAGS = {
-                   'Key': 'Solution',
-                   'Value': 'DataMeshUtils'
-               },
+    'Key': 'Solution',
+    'Value': 'DataMeshUtils'
+}
 
 DOMAIN_TAG_KEY = 'Domain'
 DATA_PRODUCT_TAG_KEY = 'DataProduct'


### PR DESCRIPTION
Fixing bug in default tags definition which causes python to serialize it as a tuple, not dict <sigh>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
