### PR TITLE
adding programatic support for aws cli Profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,29 @@ This file includes the following identities:
 
 For the example usage scripts, you can configure a file on your filesystem, and eference this file in through the `CredentialsFile` environment variable. For the `cli`, you can provide the path to this file using argument `--credentials-file`. Please make sure not to add this file to any publicly shared resources such as git forks of the codebase!
 
+### Using Profiles with ~/.aws/config
+
+If you are using named profiles in your aws config file like the below:
+
+```sh
+[profile someAccount-Admin]
+output = json
+region = eu-west-2
+credential_process = ...
+```
+
+You can use a Profile by name by supplying 'use_profile' instead of 'use_credentials
+
+```python
+mesh_admin = dmu.DataMeshAdmin(
+    data_mesh_account_id=data_mesh_account,
+    region_name=aws_region,
+    log_level=logging.DEBUG,
+    use_profile='someAccount-Admin'
+)
+```
+This can be used to supply all account profiles, for example: mesh, produce, and consumer 
+
 ## Getting Started
 
 To install AWS Data Mesh Utils, install from Pypi:

--- a/src/data_mesh_util/lib/ApiAutomator.py
+++ b/src/data_mesh_util/lib/ApiAutomator.py
@@ -660,13 +660,25 @@ class ApiAutomator:
 
     def assert_is_data_lake_admin(self, principal):
         lf_client = self._get_client('lakeformation')
-
+        lf_client_admins = lf_client.get_data_lake_settings().get('DataLakeSettings').get("DataLakeAdmins")
         admin_matched = False
-        for admin in lf_client.get_data_lake_settings().get('DataLakeSettings').get("DataLakeAdmins"):
-            if principal == admin.get('DataLakePrincipalIdentifier'):
+        for admin in lf_client_admins:
+            admin_principal = admin.get('DataLakePrincipalIdentifier')
+            print(admin_principal)
+            if principal == admin_principal:
                 admin_matched = True
                 break
-
+            if 'assumed-role' in principal:
+                principal_parts = principal.split(':')
+                admin_principal_parts = admin_principal.split(':')
+                if (principal_parts[0] == admin_principal_parts[0] and 
+                    principal_parts[1] == admin_principal_parts[1] and 
+                    principal_parts[3] == admin_principal_parts[3] and 
+                    principal_parts[4] == admin_principal_parts[4] and 
+                    admin_principal_parts[5] in principal_parts[5]
+                    ):
+                    admin_matched = True
+                    break
         if admin_matched is False:
             raise Exception(f"Principal {principal} is not Data Lake Admin")
 


### PR DESCRIPTION
Description of changes in addition to ReadMe update:

1. added 'use_profile' to bootstrap_account as an alternative to credentials, additionally account id for consumer and/or producer is determined now by using a the sts client for the appropriate connection.

2. Class DataMeshAdmin is updated to handle the new option for 'use_profile' and will use this to connect the clients if supplied, 'use_profile' can not be used at the same time as 'use_credentials' and we raise error if we try and do that.

3. the function assert_is_data_lake_admin is updated to handle the case were we use and STS assumed role and need to check that it is a data lake Admin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
